### PR TITLE
Fix Call-time pass-by-reference

### DIFF
--- a/class_parse.php
+++ b/class_parse.php
@@ -171,7 +171,7 @@ class XMLGlobal
 	{
 		//Load php's XML parser
 		$this->xml_parser = xml_parser_create();
-		xml_set_object($this->xml_parser, &$this);
+		xml_set_object($this->xml_parser, $this);
 		
 		//Parser option: Skip whitespace
 		xml_parser_set_option($this->xml_parser, XML_OPTION_SKIP_WHITE, true); 


### PR DESCRIPTION
As of PHP 5.3.0, you will get a warning saying that "call-time pass-by-reference" is deprecated when you use & in foo(&$a);. And as of PHP 5.4.0, call-time pass-by-reference was removed, so using it will raise a fatal error. 

See: http://php.net/manual/en/language.references.pass.php
